### PR TITLE
Fixed first fade in not working correctly & commented useless code

### DIFF
--- a/ext/Client/__init__.lua
+++ b/ext/Client/__init__.lua
@@ -112,11 +112,12 @@ function VEManagerClient:FadeTo(id, visibility, time)
 
 	self.m_Presets[id]['time'] = time
 	self.m_Presets[id]['startTime'] = SharedUtils:GetTimeMS()
-	self.m_Presets[id]['startValue'] = self.m_Presets[id]["logic"].visibility
-	self.m_Presets[id]['EndValue'] = visibility
+	self.m_Presets[id]['startValue'] = 0 -- Fade in should always start from 0
+	self.m_Presets[id]['EndValue'] = visibility -- this doesn't allow for a preset to have a visibility ~= 0. The basic visibility of each preset needs to be indipendent of the current visibility (aka opacity). 
 	self.m_Lerping[#self.m_Lerping + 1] = id
 end
 
+--[[
 function VEManagerClient:FadeIn(id, time)
 	if self.m_Presets[id] == nil then
 		error("There isn't a preset with this id or it hasn't been parsed yet. Id: ".. tostring(id))
@@ -129,6 +130,7 @@ function VEManagerClient:FadeIn(id, time)
 	self.m_Presets[id]['EndValue'] = 1
 	self.m_Lerping[#self.m_Lerping +1] = id
 end
+]]
 
 function VEManagerClient:FadeOut(id, time)
 	if self.m_Presets[id] == nil then


### PR DESCRIPTION
Based on: https://projects.zoho.com/portal/opspiritual#taskdetail/983287000000014343/983287000000984013/983287000000869035

Easy fix. All presets have a visibility value which is used as a starting value for the variation hence, the first time the variation starts for that initial visibility value.

In general, the visibility of a preset at a transition state (eg from 0 to X when fade in) or when it is disabled (= 0) should not be the same with the basic visibility of the preset as a VE value (eg X = 0.856). In VEManager, those 2 are the same.