### PR TITLE
Small fix for presets beyond 180°

### DIFF
--- a/ext/Client/Time.lua
+++ b/ext/Client/Time.lua
@@ -216,10 +216,6 @@ function Time:_OnAddTime(p_StartingTime, p_IsStatic, p_LengthOfDayInSeconds)
 					local s_SkyBrightness = tonumber(l_Object.rawPreset.Sky.BrightnessScale)
 
 					if l_Object.type == l_Type and s_SunRotationY ~= nil then
-						-- Check if night mode (moon enabled)
-						if s_SunRotationY >= 180 then
-							s_SunRotationY = 360 - s_SunRotationY
-						end
 						m_Logger:Write(" - " .. tostring(l_ID) .. " (Sun: " .. tostring(s_SunRotationY) .. ")")
 						table.insert(self._SortedDynamicPresetsTable, {l_ID, s_SunRotationY})
 					end

--- a/mod.json
+++ b/mod.json
@@ -3,7 +3,7 @@
 	"Authors": ["Powback", "IllustrisJack", "Lesley", "GreatApo", "FoolHen"],
 	"Description": "Handles VE",
 	"URL": "https://github.com/BF3RM/VEManager",
-	"Version": "0.5.0",
+	"Version": "0.5.1",
 	"HasWebUI": false,
 	"HasVeniceEXT": true
 }


### PR DESCRIPTION
Small fix to get rid of logic that shouldn't be there anymore since its being used somewhere else below for the moon.

This was causing presets beyond 180° (night time presets) to be corrupted with other sunY position values, messing with the sorting of the presets for the day-night cycles.