### PR TITLE
Added the capacity of only using Dynamic presets

### DIFF
--- a/ext/Client/Time.lua
+++ b/ext/Client/Time.lua
@@ -39,6 +39,8 @@ function Time:RegisterVars()
 
 	self._Sunrise = VEM_CONFIG.DN_SUN_TIMINGS[1] / 24
 	self._Sunset = VEM_CONFIG.DN_SUN_TIMINGS[2] / 24
+
+	self._DynamicTypes = { 'Dynamic', 'DefaultDynamic' }
 end
 
 function Time:RegisterEvents()
@@ -197,15 +199,13 @@ end
 ---@param p_StartingTime number
 ---@param p_IsStatic boolean
 ---@param p_LengthOfDayInSeconds number
-function Time:_OnAddTime(p_StartingTime, p_IsStatic, p_LengthOfDayInSeconds)
+function Time:_OnAddTime(p_StartingTime, p_IsStatic, p_LengthOfDayInSeconds, p_OnlyDynamicPresets)
 	if self._SystemRunning or self._FirstRun then
 		self:RegisterVars()
 	end
 	-- We hide the Vanilla preset
 	m_VisualEnvironmentHandler:SetVisibility('Vanilla', 0)
 
-
-	local dynamicTypes = { 'Dynamic', 'DefaultDynamic' }
 	m_VEMLogger:Write("Searching for dynamic presets:")
 
 	local s_VisualEnvironmentObjects = m_VisualEnvironmentHandler:GetVisualEnvironmentObjects()
@@ -244,7 +244,7 @@ function Time:_OnAddTime(p_StartingTime, p_IsStatic, p_LengthOfDayInSeconds)
 									s_SunRotationY
 							}
 						end
-					elseif table.Contains(dynamicTypes, veObject.type) then
+					elseif table.Contains(p_OnlyDynamicPresets and { "Dynamic" } or self._DynamicTypes, veObject.type) then
 						-- We save the new VE preset if its a Dynamic or DefaultDynamic
 						m_VEMLogger:Write("Saving a new preset!")
 						table.insert(self._SortedDynamicPresetsTable,

--- a/ext/Client/__init__.lua
+++ b/ext/Client/__init__.lua
@@ -397,11 +397,12 @@ function VEManagerClient:_LoadPresets()
 		m_VisualEnvironmentHandler:RegisterVisualEnvironmentObject(l_ID, s_VEObject)
 		self._RawPresets[l_ID] = nil
 	end
+	-- Enabling Vanilla by default :)
+	self._OnEnablePreset(self, 'Vanilla')
 	Events:Dispatch("VEManager:PresetsLoaded")
 	NetEvents:Send("VEManager:PresetsLoaded")
 	NetEvents:Send("VEManager:PlayerReady")
 	m_VEMLogger:Write("Presets loaded")
-	self._OnEnablePreset(self, 'Vanilla')
 end
 
 return VEManagerClient()

--- a/ext/Server/TimeServer.lua
+++ b/ext/Server/TimeServer.lua
@@ -31,6 +31,7 @@ function TimeServer:RegisterVars()
 	self.m_SyncTickrate = VEM_CONFIG.SERVER_SYNC_CLIENT_EVERY_TICKS / self.m_ServerTickrate --[Hz]
 	---@type boolean
 	self.m_SystemRunning = false
+	self.m_OnlyDynamicPresets = false
 end
 
 function TimeServer:RegisterEvents()
@@ -52,10 +53,14 @@ end
 
 ---@param p_StartingTime number
 ---@param p_LengthOfDayInMinutes number
-function TimeServer:_OnEnable(p_StartingTime, p_LengthOfDayInMinutes)
+function TimeServer:_OnEnable(p_StartingTime, p_LengthOfDayInMinutes, p_OnlyDynamicPresets)
 	if self.m_SystemRunning then
 		-- reset
 		self:RegisterVars()
+	end
+
+	if p_OnlyDynamicPresets then
+		self.m_OnlyDynamicPresets = p_OnlyDynamicPresets
 	end
 
 	-- set length of day
@@ -73,7 +78,8 @@ function TimeServer:_OnEnable(p_StartingTime, p_LengthOfDayInMinutes)
 	m_VEMLogger:Write('Received new time (Starting Time, Length of Day): ' ..
 		p_StartingTime .. 'h, ' .. self.m_TotalDayLength .. 'sec')
 
-	NetEvents:Broadcast('VEManager:AddTimeToClient', self.m_ServerDayTime, self.m_IsStatic, self.m_TotalDayLength)
+	NetEvents:Broadcast('VEManager:AddTimeToClient', self.m_ServerDayTime, self.m_IsStatic, self.m_TotalDayLength,
+		self.m_OnlyDynamicPresets)
 	self.m_SystemRunning = true
 end
 
@@ -108,7 +114,7 @@ function TimeServer:_OnPlayerSync(p_Player)
 	if self.m_SystemRunning == true or self.m_IsStatic == true then
 		m_VEMLogger:Write('Syncing Player with Server')
 		NetEvents:SendTo('VEManager:AddTimeToClient', p_Player, self.m_ServerDayTime, self.m_IsStatic,
-			self.m_TotalDayLength)
+			self.m_TotalDayLength, self.m_OnlyDynamicPresets)
 	end
 end
 
@@ -136,7 +142,7 @@ end
 ---@param p_Message string
 function TimeServer:ChatCommands(p_PlayerName, p_RecipientMask, p_Message)
 	if p_Message:match('^!settime') then
-		local hour, duration = p_Message:match('^!settime (%d+%.*%d*) (%d+%.*%d*)')
+		local hour, duration, onlyDynamicPresets = p_Message:match('^!settime (%d+%.*%d*) (%d+%.*%d*) (%a)')
 
 		if hour == nil then
 			hour = 9
@@ -146,8 +152,12 @@ function TimeServer:ChatCommands(p_PlayerName, p_RecipientMask, p_Message)
 			duration = 0.5
 		end
 
+		if onlyDynamicPresets == "true" then
+			onlyDynamicPresets = true
+		end
+
 		m_VEMLogger:Write('Time Event called by ' .. p_PlayerName)
-		self:_OnEnable(hour, duration)
+		self:_OnEnable(hour, duration, onlyDynamicPresets)
 	elseif p_Message == '!setnight' then
 		m_VEMLogger:Write('Time Event called by ' .. p_PlayerName)
 		self:_OnEnable(0, nil)

--- a/ext/Server/TimeServer.lua
+++ b/ext/Server/TimeServer.lua
@@ -142,7 +142,7 @@ end
 ---@param p_Message string
 function TimeServer:ChatCommands(p_PlayerName, p_RecipientMask, p_Message)
 	if p_Message:match('^!settime') then
-		local hour, duration, onlyDynamicPresets = p_Message:match('^!settime (%d+%.*%d*) (%d+%.*%d*) (%a)')
+		local hour, duration = p_Message:match('^!settime (%d+%.*%d*) (%d+%.*%d*)')
 
 		if hour == nil then
 			hour = 9
@@ -152,12 +152,9 @@ function TimeServer:ChatCommands(p_PlayerName, p_RecipientMask, p_Message)
 			duration = 0.5
 		end
 
-		if onlyDynamicPresets == "true" then
-			onlyDynamicPresets = true
-		end
 
 		m_VEMLogger:Write('Time Event called by ' .. p_PlayerName)
-		self:_OnEnable(hour, duration, onlyDynamicPresets)
+		self:_OnEnable(hour, duration)
 	elseif p_Message == '!setnight' then
 		m_VEMLogger:Write('Time Event called by ' .. p_PlayerName)
 		self:_OnEnable(0, nil)

--- a/ext/Shared/Config.lua
+++ b/ext/Shared/Config.lua
@@ -10,7 +10,7 @@ VEM_CONFIG = {
 
     -- PRINT --
     PRINT_DN_TIME_AND_VISIBILITIES = true, -- Print current time every hour along with the visibilities of the 4 presets
-    VEMLogger_ENABLED = false,             -- Enables the use of the VEMLogger Class [DEV]
+    VEMLogger_ENABLED = true,              -- Enables the use of the VEMLogger Class [DEV]
     VEMLogger_PRINT_ALL = false,           -- Prints All VEMLogger Prints
 
     -- SERVER --


### PR DESCRIPTION
This is going to need some changes in the RM code since we are now recieving another parameter for the event handler in VEM side.

So, I assume somwhere in the code of RM in the server side scripts its being send an event to VEM to AddTime to a map when its loaded, in order to avoid using the default presets and only use the custom Dynamic ones only, a new parameter is needed, if sent only those will be loaded for the day cycle.

If not, it will try to use the defaultDynamic ones but if there are Dynamic presets registered for the same Y axis coordinates they will replace the default ones.

@Dumpy250 please review and test with RM