### PR TITLE
Time bugfixing

### DIFF
--- a/ext/Client/__init__.lua
+++ b/ext/Client/__init__.lua
@@ -39,7 +39,7 @@ function VEManagerClient:RegisterVars()
 end
 
 function VEManagerClient:RegisterEvents()
-	Events:Subscribe('Partition:Loaded', self, self._OnPartitionLoaded)
+	--Events:Subscribe('Partition:Loaded', self, self._OnPartitionLoaded)
 	Events:Subscribe('Level:Loaded', self, self._OnLevelLoaded)
 	Events:Subscribe('Level:Destroy', self, self._OnLevelDestroy)
 	Events:Subscribe('UpdateManager:Update', self, self._OnUpdateManager)


### PR DESCRIPTION
Solved a bug that caused time to reset as soon as a player reconnected.

Also solved a sub-bug caused by the first fix of this, that caused the chat commands for time cycle to not work.



The commented event for `Partition:loaded` will come back in another branch called `assets-patching-fix ` but tits a separated thing.