### PR TITLE
fix: don´t initialize a preset that will be destroyed right away

### DIFF
--- a/ext/Client/VisualEnvironmentHandler.lua
+++ b/ext/Client/VisualEnvironmentHandler.lua
@@ -201,18 +201,24 @@ function VisualEnvironmentHandler:SetVisibility(p_ID, p_Visibility)
 	local s_Object = self._VisualEnvironmentObjects[p_ID]
 
 	if not s_Object.entity then
-		self:InitializeVE(p_ID, p_Visibility)
-	elseif p_Visibility <= 0.0 then
-		self:DestroyVE(p_ID)
-	else
-		s_Object.ve.visibility = p_Visibility
-		local s_State = VisualEnvironmentEntity(s_Object.entity).state
-
-		if s_State then
-			s_State.visibility = p_Visibility
-			VisualEnvironmentManager:SetDirty(true)
+		if p_Visibility <= 0.0 then
+			return -- Don´t initialize a preset that will be destroyed right away
 		else
-			self:Reload(p_ID)
+			self:InitializeVE(p_ID, p_Visibility)
+		end
+	elseif s_Object.entity then
+		if p_Visibility <= 0.0 then
+			self:DestroyVE(p_ID)
+		else
+			s_Object.ve.visibility = p_Visibility
+			local s_State = VisualEnvironmentEntity(s_Object.entity).state
+
+			if s_State then
+				s_State.visibility = p_Visibility
+				VisualEnvironmentManager:SetDirty(true)
+			else
+				self:Reload(p_ID)
+			end
 		end
 	end
 

--- a/mod.json
+++ b/mod.json
@@ -9,7 +9,7 @@
 	],
 	"Description": "Handles VE",
 	"URL": "https://github.com/BF3RM/VEManager",
-	"Version": "0.5.7",
+	"Version": "0.5.8",
 	"HasWebUI": false,
 	"HasVeniceEXT": true
 }


### PR DESCRIPTION
VEM will not create VEs anymore that will be destroyed right away. (Visibility 0)